### PR TITLE
Add Single Sign Out/In support

### DIFF
--- a/getekid/cas/auth/provider/cas.php
+++ b/getekid/cas/auth/provider/cas.php
@@ -88,7 +88,9 @@ class cas extends \phpbb\auth\provider\base
 				// THIS SETTING IS NOT RECOMMENDED FOR PRODUCTION.
 				// VALIDATING THE CAS SERVER IS CRUCIAL TO THE SECURITY OF THE CAS PROTOCOL!
 				phpCAS::setNoCasServerValidation();
-			}
+            }
+
+            phpCAS::handleLogoutRequests(false);
 		}
 		// Disable super globals
 		$this->request->disable_super_globals();

--- a/getekid/cas/event/cas_login_listener.php
+++ b/getekid/cas/event/cas_login_listener.php
@@ -64,13 +64,13 @@ class cas_login_listener implements EventSubscriberInterface
 	}
 
 	public function login_after_cas_redirect($event)
-	{
-        if ($this->user->data['username'] == 'Anonymous') {
-            $_SESSION['phpBBCAS'] = true;
+    {
+        if ($this->user->data['username'] == 'Anonymous' &&
+            array_key_exists('phpCAS', $_SESSION)) {
+            unset($_SESSION['phpBBCAS']);
             $result = $this->auth->login('', '');
         } else {
-            if (!array_key_exists('phpCAS', $_SESSION))
-                $this->user->session_kill();
+            $this->user->session_kill();
         }
 
         // Get the ticket from the URL and login in order to validate it

--- a/getekid/cas/event/cas_login_listener.php
+++ b/getekid/cas/event/cas_login_listener.php
@@ -58,14 +58,22 @@ class cas_login_listener implements EventSubscriberInterface
 		$this->config = $config;
 		$this->request = $request;
 		$this->auth = $auth;
-		$this->user = $user;
+        $this->user = $user;
 		$this->template = $template;
 		$this->phpbb_root_path = $phpbb_root_path;
 	}
 
 	public function login_after_cas_redirect($event)
 	{
-		// Get the ticket from the URL and login in order to validate it
+        if ($this->user->data['username'] == 'Anonymous') {
+            $_SESSION['phpBBCAS'] = true;
+            $result = $this->auth->login('', '');
+        } else {
+            if (!array_key_exists('phpCAS', $_SESSION))
+                $this->user->session_kill();
+        }
+
+        // Get the ticket from the URL and login in order to validate it
 		$cas_ticket = $this->request->variable('ticket', '', true, \phpbb\request\request_interface::GET);
 		if ($cas_ticket)
 		{


### PR DESCRIPTION
[phpCAS supports Single Sign Out] (https://wiki.jasig.org/display/casc/phpcas+examples#phpCASexamples-HandlelogoutrequestsfromtheCASserver) when, for example, logout from WordPress, then phpBB3 need to logout automatically.

So I just added

```
if ($this->user->data['username'] == 'Anonymous') {                        
            $_SESSION['phpBBCAS'] = true;                                          
            $result = $this->auth->login('', '');                                  
        } else {                                                                   
            if (!array_key_exists('phpCAS', $_SESSION))                            
                $this->user->session_kill();                                       
        }
```

in event/cas_login_listener.php to support single sign out/in.