### PR TITLE
trigger login event after session created

### DIFF
--- a/event/cas_login_listener.php
+++ b/event/cas_login_listener.php
@@ -57,6 +57,7 @@ class cas_login_listener implements EventSubscriberInterface
 	public static function getSubscribedEvents()
 	{
 		return array(
+			'core.session_create_after' => 'login_after_cas_redirect',
 			'core.update_session_after' => 'login_after_cas_redirect',
 			'core.index_modify_page_title' => 'add_cas_login_text',
 		);


### PR DESCRIPTION
This plugin works well when we use a CAS login page, but if we have a system with a custom login mechanism,  and we cannot change it, we have to use CAS rest api  to login to a service.
When using this method, we open a url like http://example.com/?ticket=xxxxx to login. If we do not subscribe core.session_create_after, we have to open the url twice to login.
I'm not familiar with php and phpbb, but after two days' work, I found a nice solution. I don't know whether it's correct or I have missed something. But it works for me.